### PR TITLE
Fix capitalization zl-util

### DIFF
--- a/src/zl-util/ZLFrustumFitter.cpp
+++ b/src/zl-util/ZLFrustumFitter.cpp
@@ -2,7 +2,7 @@
 // http://getmoai.com
 
 #include "pch.h"
-#include <zl-util/ZLFrustumFItter.h>
+#include <zl-util/ZLFrustumFitter.h>
 #include <zl-util/ZLDistance.h>
 #include <zl-util/ZLIntersect.h>
 #include <zl-util/ZLMathConsts.h>


### PR DESCRIPTION
Fix the include to remove the capital "I" in #include <zl-util/ZLFrustumFitter.h>
Was working for non case-sensitive filesystems. But doesn't for case-sensitive ones.
